### PR TITLE
Allow overriding API key with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ Create a JSON configuration file with the following structure:
 }
 ```
 
+You can also set the environment variable `OPENAI_API_KEY` to override the
+`api_key` values in the configuration file. This allows sharing configuration
+files without including secrets.
+
 ## Usage
 
 ```bash

--- a/src/config_handler.py
+++ b/src/config_handler.py
@@ -17,7 +17,15 @@ class ConfigHandler:
         """
         self.config_path = config_path
         self.config = self._load_config()
+        self._apply_env_overrides()
         self._validate_config()
+
+    def _apply_env_overrides(self) -> None:
+        """Override configuration values using environment variables."""
+        env_api_key = os.getenv("OPENAI_API_KEY")
+        if env_api_key:
+            for model in self.config.get("models", []):
+                model["api_key"] = env_api_key
         
     def _load_config(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary
- support overriding API keys with `OPENAI_API_KEY`
- document the override in the README

## Testing
- `python tests/run_mock_test.py --config config/test_config.json --no-report --no-analysis`