### PR TITLE
Add asyncio HTTP support for Ray requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Concurrent requests are executed using Ray tasks running on your local machine, 
 ## Requirements
 
 - Python 3.8+
-- Required packages: ray, llmperf, matplotlib, pandas, python-docx, tqdm, requests
+- Required packages: ray, llmperf, matplotlib, pandas, python-docx, tqdm, requests, aiohttp
 
 ## Installation
 
@@ -27,7 +27,7 @@ git clone https://github.com/yourusername/llm-stress-tool.git
 cd llm-stress-tool
 
 # Install dependencies
-pip install ray llmperf matplotlib pandas python-docx tqdm requests
+pip install ray llmperf matplotlib pandas python-docx tqdm requests aiohttp
 ```
 
 ## Configuration

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "python-docx",
         "tqdm",
         "requests",
+        "aiohttp",
     ],
     entry_points={
         "console_scripts": [

--- a/src/ray_requests.py
+++ b/src/ray_requests.py
@@ -1,13 +1,13 @@
 import time
 from typing import Dict, Any
 
-import requests
+import aiohttp
 import ray
 
 
 @ray.remote
-def make_request(base_url: str, headers: Dict[str, str], model_name: str, prompt: str) -> Dict[str, Any]:
-    """Ray task to make a single request to the LLM API."""
+async def make_request(base_url: str, headers: Dict[str, str], model_name: str, prompt: str) -> Dict[str, Any]:
+    """Asynchronous Ray task to make a single request to the LLM API."""
     endpoint = f"{base_url}/chat/completions"
     payload = {
         "model": model_name,
@@ -18,9 +18,10 @@ def make_request(base_url: str, headers: Dict[str, str], model_name: str, prompt
 
     start_time = time.time()
     try:
-        response = requests.post(endpoint, headers=headers, json=payload)
-        response.raise_for_status()
-        response_data = response.json()
+        async with aiohttp.ClientSession(headers=headers) as session:
+            async with session.post(endpoint, json=payload) as response:
+                response.raise_for_status()
+                response_data = await response.json()
 
         end_time = time.time()
         latency = end_time - start_time


### PR DESCRIPTION
## Summary
- make Ray remote request use aiohttp and async def
- require aiohttp in setup
- update README for aiohttp dependency

## Testing
- `python tests/run_mock_test.py --config config/config_template.json --no-report --no-analysis`