### PR TITLE
Fix ray request import issues

### DIFF
--- a/src/llm_tester.py
+++ b/src/llm_tester.py
@@ -4,7 +4,10 @@ from typing import Dict, List, Any
 import requests
 from tqdm import tqdm
 import ray
-from .ray_requests import make_request
+try:
+    from .ray_requests import make_request
+except ImportError:  # Allow running without package context
+    from src.ray_requests import make_request
 
 
 class LLMTester:

--- a/src/llmperf_integration.py
+++ b/src/llmperf_integration.py
@@ -5,7 +5,10 @@ import requests
 import time
 from tqdm import tqdm
 import ray
-from .ray_requests import make_request
+try:
+    from .ray_requests import make_request
+except ImportError:  # Allow running without package context
+    from src.ray_requests import make_request
 
 # Remove the dependency on llmperf.benchmark
 class LLMPerfRunner:

--- a/src/ray_requests.py
+++ b/src/ray_requests.py
@@ -1,13 +1,13 @@
 import time
 from typing import Dict, Any
 
-import aiohttp
+import requests
 import ray
 
 
 @ray.remote
-async def make_request(base_url: str, headers: Dict[str, str], model_name: str, prompt: str) -> Dict[str, Any]:
-    """Asynchronous Ray task to make a single request to the LLM API."""
+def make_request(base_url: str, headers: Dict[str, str], model_name: str, prompt: str) -> Dict[str, Any]:
+    """Ray task to make a single request to the LLM API."""
     endpoint = f"{base_url}/chat/completions"
     payload = {
         "model": model_name,
@@ -18,10 +18,9 @@ async def make_request(base_url: str, headers: Dict[str, str], model_name: str, 
 
     start_time = time.time()
     try:
-        async with aiohttp.ClientSession(headers=headers) as session:
-            async with session.post(endpoint, json=payload) as response:
-                response.raise_for_status()
-                response_data = await response.json()
+        response = requests.post(endpoint, headers=headers, json=payload)
+        response.raise_for_status()
+        response_data = response.json()
 
         end_time = time.time()
         latency = end_time - start_time


### PR DESCRIPTION
## Summary
- load make_request from src when relative import fails
- use synchronous requests in ray tasks

## Testing
- `python tests/run_mock_test.py --config config/test_config.json --output-dir results --no-report --no-analysis`